### PR TITLE
Start linting SCSS with Sasslint!

### DIFF
--- a/.sasslint.json
+++ b/.sasslint.json
@@ -1,0 +1,11 @@
+{
+  "rules": {
+    "BorderZero": {
+      "enabled": true,
+      "convention": "0"
+    },
+    "SpaceAfterPropertyColon": {
+      "enabled": true
+    }
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-/* jshint node:true */
+/* eslint-disable */
 "use strict";
 
 var webpack = require('webpack');
@@ -210,12 +210,19 @@ module.exports = function(grunt) {
     },
 
     /**
+     * Lint SCSS using Sasslint.
+     */
+    sasslint: {
+      all: ['scss/**/*.scss'],
+    },
+
+    /**
      * Watch files for changes, and trigger relevant tasks.
      */
     watch: {
       sass: {
         files: ["scss/**/*.scss"],
-        tasks: ["sass:debug", "postcss:debug"]
+        tasks: ["sass:debug", "postcss:debug", "sasslint"]
       },
       js: {
         files: ["js/**/*.js"],
@@ -246,7 +253,7 @@ module.exports = function(grunt) {
 
   // > grunt test
   // Run included unit tests and linters.
-  grunt.registerTask('test', ['eslint']);
+  grunt.registerTask('test', ['eslint', 'sasslint']);
 
 };
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "grunt-modernizr": "^0.6.0",
     "grunt-postcss": "^0.2.0",
     "grunt-sass": "^0.18.0",
+    "grunt-sasslint": "0.0.5",
     "grunt-webpack": "^1.0.8",
     "highlight.js": "^8.4.0",
     "html5shiv": "aFarkas/html5shiv.git#3.7.2",


### PR DESCRIPTION
# Changes
Start linting our SCSS with [Sasslint](https://github.com/DFurnes/sasslint). Currently, the only two linting rules are [BorderZero](https://github.com/DFurnes/sasslint/blob/d3f0456db593a48f782835d8a8b4fcbf13c91140/src/Linters/BorderZero.js) (prefer `0` to `none`) and [SpaceAfterPropertyColon](https://github.com/DFurnes/sasslint/blob/master/src/Linters/SpaceAfterPropertyColon.js) (prefer one space after `:` in declarations). But it's pretty cool to be able to actually start using this in production! :zap: 

<img width="289" alt="screen shot 2015-08-04 at 8 52 52 am" src="https://cloud.githubusercontent.com/assets/583202/9060940/35efd184-3a86-11e5-8ac8-17ada756abeb.png">


For review: @DoSomething/front-end 